### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "tsc"
   },
   "peerDependencies": {
-    "react": "^16.7.0-alpha.0"
+    "react": "^16.8"
   },
   "files": [
     "build/index.js",
@@ -37,7 +37,7 @@
     "jest": "^26.6.3",
     "prettier": "1.14.3",
     "pretty-quick": "^1.8.0",
-    "react": "^16.7.0-alpha.0",
+    "react": "^16.8",
     "ts-jest": "^26.4.4",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3",


### PR DESCRIPTION
Pretty sure there's no need to use `alpha` release of React? And hooks are supported from the stable release of `React@16.8`, so I think that should be the peer dependency.