### PR TITLE
Add `repository` field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "use-mobile-detect-hook",
   "version": "1.0.4",
   "description": "The React hook to detect if the device is mobile or desktop.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/haldarmahesh/use-mobile-detect-hook.git"
+  },
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {


### PR DESCRIPTION
# Summary
Added a repository field to the package.json to give tools and users of the package a reference back to the repository.
Reasoning: We use a tool to generate a list of all packages used in a repository, this adds a way for us to reference back to this repository. The change should also be useful to other users as well.

Documentation on the `repository` field: https://docs.npmjs.com/cli/v6/configuring-npm/package-json#repository